### PR TITLE
Add law database with lookup tool

### DIFF
--- a/src/laws/db.py
+++ b/src/laws/db.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Utility classes for storing and querying law texts."""
+
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import Column, Integer, String, Text, create_engine, select
+from sqlalchemy.orm import Session, declarative_base
+
+
+Base = declarative_base()
+
+
+class LawSection(Base):
+    __tablename__ = "law_sections"
+
+    id = Column(Integer, primary_key=True)
+    abbreviation = Column(String, index=True)
+    doc_number = Column(String, index=True)
+    section = Column(String, index=True)
+    title = Column(String)
+    text = Column(Text)
+
+
+@dataclass
+class LawDatabase:
+    """Simple SQLite-backed database for German laws."""
+
+    db_path: str = "laws.db"
+
+    def __post_init__(self) -> None:
+        self.engine = create_engine(f"sqlite:///{self.db_path}")
+        Base.metadata.create_all(self.engine)
+
+    def ingest_zip_url(self, url: str) -> None:
+        """Download a zip file containing an XML law document and ingest it."""
+        import requests
+
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = os.path.join(tmp, "law.zip")
+            with open(zip_path, "wb") as f:
+                f.write(response.content)
+            self.ingest_zip_file(zip_path)
+
+    def ingest_zip_file(self, zip_path: str) -> None:
+        """Ingest a local xml.zip archive."""
+        with zipfile.ZipFile(zip_path) as zf:
+            xml_name = next((n for n in zf.namelist() if n.endswith(".xml")), None)
+            if not xml_name:
+                raise ValueError("No XML file found in archive")
+            with zf.open(xml_name) as f:
+                self.ingest_xml_bytes(f.read())
+
+    def ingest_xml_bytes(self, data: bytes) -> None:
+        root = ET.fromstring(data)
+        with Session(self.engine) as session:
+            for norm in root.findall("norm"):
+                meta = norm.find("metadaten")
+                if meta is None:
+                    continue
+                section = meta.findtext("enbez")
+                if not section:
+                    continue
+                title = meta.findtext("titel", default="")
+                jbs = [j.text for j in meta.findall("jurabk") if j.text]
+                abbreviation = jbs[-1] if jbs else None
+                doc_number = norm.get("doknr") or ""
+                text_elem = norm.find("textdaten/text")
+                text = ""
+                if text_elem is not None:
+                    text = "".join(text_elem.itertext()).strip()
+                session.add(
+                    LawSection(
+                        abbreviation=abbreviation,
+                        doc_number=doc_number,
+                        section=section,
+                        title=title,
+                        text=text,
+                    )
+                )
+            session.commit()
+
+    def query_section(
+        self, abbreviation: str, section: str
+    ) -> Optional[LawSection]:
+        with Session(self.engine) as session:
+            stmt = (
+                select(LawSection)
+                .where(LawSection.abbreviation == abbreviation)
+                .where(LawSection.section == section)
+            )
+            return session.scalars(stmt).first()

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -7,10 +7,12 @@ from .crawl import crawl_tool
 from .python_repl import python_repl_tool
 from .search import get_web_search_tool
 from .tts import VolcengineTTS
+from .law import law_lookup
 
 __all__ = [
     "crawl_tool",
     "python_repl_tool",
     "get_web_search_tool",
     "VolcengineTTS",
+    "law_lookup",
 ]

--- a/src/tools/law.py
+++ b/src/tools/law.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Tool for retrieving law sections from the local database."""
+
+import logging
+from typing import Annotated
+
+from langchain_core.tools import tool
+
+from src.laws.db import LawDatabase
+from .decorators import log_io
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+@log_io
+def law_lookup(
+    section: Annotated[str, "Section number like '§ 1a'"],
+    abbreviation: Annotated[str, "Law abbreviation like 'UStG'"],
+    db_path: str = "laws.db",
+) -> dict[str, str] | str:
+    """Lookup a law section by abbreviation and section number."""
+    db = LawDatabase(db_path)
+    result = db.query_section(abbreviation, section)
+    if result is None:
+        return f"Section {section} not found in {abbreviation}."
+    return {"title": result.title, "text": result.text}

--- a/tests/integration/test_law_tool.py
+++ b/tests/integration/test_law_tool.py
@@ -1,0 +1,14 @@
+from src.laws.db import LawDatabase
+from src.tools.law import law_lookup
+
+
+def test_law_ingestion_and_lookup(tmp_path):
+    db_path = tmp_path / "laws.db"
+    db = LawDatabase(str(db_path))
+    db.ingest_zip_file("xml.zip")
+
+    result = law_lookup("§ 1a", "UStG", db_path=str(db_path))
+    assert isinstance(result, dict)
+    assert "Innergemeinschaftlicher Erwerb" in result["title"]
+    assert len(result["text"]) > 0
+


### PR DESCRIPTION
## Summary
- ingest law XML archives into SQLite via new `LawDatabase`
- expose `law_lookup` tool for retrieving law sections
- export `law_lookup` in tools package
- test ingestion and lookup using provided `xml.zip`

## Testing
- `make lint` *(fails: No route to host)*
- `make test` *(fails: No route to host)*