### PR TITLE
Add law_lookup to agent tools

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -17,6 +17,7 @@ from src.tools.search import LoggedTavilySearch
 from src.tools import (
     crawl_tool,
     get_web_search_tool,
+    law_lookup,
     python_repl_tool,
 )
 
@@ -472,7 +473,11 @@ async def researcher_node(
         state,
         config,
         "researcher",
-        [get_web_search_tool(configurable.max_search_results), crawl_tool],
+        [
+            get_web_search_tool(configurable.max_search_results),
+            crawl_tool,
+            law_lookup,
+        ],
     )
 
 

--- a/src/laws/db.py
+++ b/src/laws/db.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Utility classes for storing and querying law texts."""
+
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import Column, Integer, String, Text, create_engine, select
+from sqlalchemy.orm import Session, declarative_base
+
+
+Base = declarative_base()
+
+
+class LawSection(Base):
+    __tablename__ = "law_sections"
+
+    id = Column(Integer, primary_key=True)
+    abbreviation = Column(String, index=True)
+    doc_number = Column(String, index=True)
+    section = Column(String, index=True)
+    title = Column(String)
+    text = Column(Text)
+
+
+@dataclass
+class LawDatabase:
+    """Simple SQLite-backed database for German laws."""
+
+    db_path: str = "laws.db"
+
+    def __post_init__(self) -> None:
+        self.engine = create_engine(f"sqlite:///{self.db_path}")
+        Base.metadata.create_all(self.engine)
+
+    def ingest_zip_url(self, url: str) -> None:
+        """Download a zip file containing an XML law document and ingest it."""
+        import requests
+
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = os.path.join(tmp, "law.zip")
+            with open(zip_path, "wb") as f:
+                f.write(response.content)
+            self.ingest_zip_file(zip_path)
+
+    def ingest_zip_file(self, zip_path: str) -> None:
+        """Ingest a local xml.zip archive."""
+        with zipfile.ZipFile(zip_path) as zf:
+            xml_name = next((n for n in zf.namelist() if n.endswith(".xml")), None)
+            if not xml_name:
+                raise ValueError("No XML file found in archive")
+            with zf.open(xml_name) as f:
+                self.ingest_xml_bytes(f.read())
+
+    def ingest_xml_bytes(self, data: bytes) -> None:
+        root = ET.fromstring(data)
+        with Session(self.engine) as session:
+            for norm in root.findall("norm"):
+                meta = norm.find("metadaten")
+                if meta is None:
+                    continue
+                section = meta.findtext("enbez")
+                if not section:
+                    continue
+                title = meta.findtext("titel", default="")
+                jbs = [j.text for j in meta.findall("jurabk") if j.text]
+                abbreviation = jbs[-1] if jbs else None
+                doc_number = norm.get("doknr") or ""
+                text_elem = norm.find("textdaten/text")
+                text = ""
+                if text_elem is not None:
+                    text = "".join(text_elem.itertext()).strip()
+                session.add(
+                    LawSection(
+                        abbreviation=abbreviation,
+                        doc_number=doc_number,
+                        section=section,
+                        title=title,
+                        text=text,
+                    )
+                )
+            session.commit()
+
+    def query_section(
+        self, abbreviation: str, section: str
+    ) -> Optional[LawSection]:
+        with Session(self.engine) as session:
+            stmt = (
+                select(LawSection)
+                .where(LawSection.abbreviation == abbreviation)
+                .where(LawSection.section == section)
+            )
+            return session.scalars(stmt).first()

--- a/src/prompts/researcher.md
+++ b/src/prompts/researcher.md
@@ -13,6 +13,7 @@ You have access to two types of tools:
 1. **Built-in Tools**: These are always available:
    - **web_search_tool**: For performing web searches
    - **crawl_tool**: For reading content from URLs
+   - **law_lookup**: For retrieving German law sections from the local database
 
 2. **Dynamic Loaded Tools**: Additional tools that may be available depending on the configuration. These tools are loaded dynamically and will appear in your available tools list. Examples include:
    - Specialized search tools

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -7,10 +7,12 @@ from .crawl import crawl_tool
 from .python_repl import python_repl_tool
 from .search import get_web_search_tool
 from .tts import VolcengineTTS
+from .law import law_lookup
 
 __all__ = [
     "crawl_tool",
     "python_repl_tool",
     "get_web_search_tool",
     "VolcengineTTS",
+    "law_lookup",
 ]

--- a/src/tools/law.py
+++ b/src/tools/law.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Tool for retrieving law sections from the local database."""
+
+import logging
+from typing import Annotated
+
+from langchain_core.tools import tool
+
+from src.laws.db import LawDatabase
+from .decorators import log_io
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+@log_io
+def law_lookup(
+    section: Annotated[str, "Section number like '§ 1a'"],
+    abbreviation: Annotated[str, "Law abbreviation like 'UStG'"],
+    db_path: str = "laws.db",
+) -> dict[str, str] | str:
+    """Lookup a law section by abbreviation and section number."""
+    db = LawDatabase(db_path)
+    result = db.query_section(abbreviation, section)
+    if result is None:
+        return f"Section {section} not found in {abbreviation}."
+    return {"title": result.title, "text": result.text}

--- a/tests/integration/test_law_tool.py
+++ b/tests/integration/test_law_tool.py
@@ -1,0 +1,14 @@
+from src.laws.db import LawDatabase
+from src.tools.law import law_lookup
+
+
+def test_law_ingestion_and_lookup(tmp_path):
+    db_path = tmp_path / "laws.db"
+    db = LawDatabase(str(db_path))
+    db.ingest_zip_file("xml.zip")
+
+    result = law_lookup("§ 1a", "UStG", db_path=str(db_path))
+    assert isinstance(result, dict)
+    assert "Innergemeinschaftlicher Erwerb" in result["title"]
+    assert len(result["text"]) > 0
+

--- a/tests/integration/test_researcher_default_tools.py
+++ b/tests/integration/test_researcher_default_tools.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import patch
+
+from src.graph.nodes import researcher_node
+from src.graph.types import State
+from src.prompts.planner_model import Plan, Step, StepType
+from langgraph.types import Command
+
+
+@pytest.mark.asyncio
+async def test_researcher_node_includes_law_lookup():
+    step = Step(
+        need_web_search=False,
+        title="test",
+        description="desc",
+        step_type=StepType.RESEARCH,
+    )
+    plan = Plan(
+        locale="en-US",
+        has_enough_context=True,
+        thought="",
+        title="",
+        steps=[step],
+    )
+    state = State(messages=[], current_plan=plan)
+    captured_tools = []
+
+    async def fake_execute(state, agent, agent_type):
+        return Command(update={}, goto="research_team")
+
+    def fake_create_agent(agent_name, agent_type, tools, prompt_template):
+        captured_tools.extend(tools)
+
+        class DummyAgent:
+            async def ainvoke(self, input, config):
+                return {"messages": [{"content": ""}]}
+
+        return DummyAgent()
+
+    with patch("src.graph.nodes.create_agent", side_effect=fake_create_agent), patch(
+        "src.graph.nodes._execute_agent_step", side_effect=fake_execute
+    ):
+        await researcher_node(state, {"configurable": {}})
+
+    tool_names = {
+        getattr(tool, "name", getattr(tool, "__name__", "")) for tool in captured_tools
+    }
+    assert "law_lookup" in tool_names


### PR DESCRIPTION
## Summary
- include `law_lookup` import and tool in `researcher_node`
- document the new law tool in the researcher prompt
- add regression test ensuring the tool is present

## Testing
- `make format` *(fails: No route to host)*
- `make lint` *(fails: No route to host)*
- `make test` *(fails: No route to host)*