### PR TITLE
Add AGENTS file with lint and test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS instructions for DeerFlow
+
+## Scope
+These instructions apply to the entire repository.
+
+## Testing and Linting
+Run the following commands after any change to this repository:
+
+```bash
+make lint
+make test
+```
+
+If the commands fail due to missing dependencies or network restrictions, mention this in your pull request.


### PR DESCRIPTION
## Summary
- add root AGENTS instructions requiring `make lint` and `make test`

## Testing
- `make lint` *(failed: No route to host)*
- `make test` *(failed: No route to host)*